### PR TITLE
`sys.platform()` > `sys.platform.startswith()`, removed `-mt` suffix

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -7,7 +7,7 @@ longdesc = """ Python Bindings for LibMEI. """
 
 if sys.platform == "darwin":
     link_args = ["-F", "/Library/Frameworks","-framework", "mei"]
-    libraries = ["boost_python-mt"]
+    libraries = ["boost_python"]
     library_dirs = []
     runtime_library_dirs = []
     include_dirs = []
@@ -18,18 +18,18 @@ elif sys.platform == "freebsd8":
     include_dirs = ['/usr/local/include']
     link_args = ["-L/usr/local/lib", "-L/usr/lib"]
 else:
-    if sys.platform == "linux2":
+    if sys.platform.startswith('linux'):
         import platform
         if platform.linux_distribution()[0] == "Ubuntu":
             # Ubuntu names its boost libraries a bit differently.
             # figure out what version of python
             ver = platform.python_version_tuple()
-            libraries = ["boost_python-mt-py{0}{1}".format(ver[0], ver[1]), "mei", "boost_python-py{0}{1}".format(ver[0], ver[1])]
+            libraries = ["boost_python-py{0}{1}".format(ver[0], ver[1]), "mei", "boost_python-py{0}{1}".format(ver[0], ver[1])]
             library_dirs = ["/usr/local/lib", "/usr/lib"]
             runtime_library_dirs = ["/usr/local/lib", "/usr/lib"]
             include_dirs = []
         else:
-            libraries = ["boost_python-mt", "mei"]
+            libraries = ["boost_python", "mei"]
             library_dirs = ["/usr/local/lib", "/usr/lib"]
             runtime_library_dirs = ["/usr/local/lib", "/usr/lib"]
             include_dirs = []


### PR DESCRIPTION
`sys.platform` now returns "linux" and does not include the kernel number anymore (https://bugs.python.org/issue12326). It is better to use `sys.platform.startswith('linux')`.

The `-mt` suffix has been removed starting from Boost 1.41 (https://askubuntu.com/questions/486006/cannot-find-boost-thread-mt-library?answertab=votes#tab-top)