### PR TITLE
Pr/manuscript syntax fixes

### DIFF
--- a/tools/langs/manuscript.py
+++ b/tools/langs/manuscript.py
@@ -839,7 +839,6 @@ generateRandomID "() {
     id = 'm-' & id;
     return id;
 }"
-}
 """
 
 AUTHORS = "Andrew Hankinson, Alastair Porter, and Others"


### PR DESCRIPTION
Linter flagged some syntax errors of libmei.plg that I fixed. ~~`lookBack()` is now syntactically correct, but is still untested (and not used anywhere).~~

Edit: I have to correct myself.  There was only one actual syntax error, which is the surplus trailing brace.