### PR TITLE
Manuscript: Write "tail" after element

### DIFF
--- a/tools/langs/manuscript.py
+++ b/tools/langs/manuscript.py
@@ -360,11 +360,6 @@ GetTail "(element) {
         indent = indent - 1;
     }
 
-    if (Length(tl) > 0)
-    {
-        xmlout = xmlout & tl;
-    }
-
     // convertDictToXml takes care of adding the />
     // for tags that do not have children. We'll
     // take care of the terminal tag here for those
@@ -382,6 +377,11 @@ GetTail "(element) {
             xmlout = xmlout & tabs & '</' & nm & '>
 ';
         }
+    }
+
+    if (Length(tl) > 0)
+    {
+        xmlout = xmlout & tl;
     }
 
     return xmlout;


### PR DESCRIPTION
Previously, this was only the case for self-closing elements