### PR TITLE
No errors on deprecated warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ set( LIBMEI_H
 
 if (CMAKE_COMPILER_IS_GNUCXX)
     add_definitions( -Werror )
+    add_definitions( -Wno-error=deprecated )
 endif (CMAKE_COMPILER_IS_GNUCXX)
 
 INCLUDE_DIRECTORIES(


### PR DESCRIPTION
Since some features are deprecated (and more possibly will be
eventually), keep errors on warnings (-Werror) but also add an exception
to just warn on deprecation (-Wno-error=deprecated) rather than fail.

This keeps deprecation warnings visible and also causes more serious
warnings (like uninitialized variables/pointers) to error.

This addresses issue #110.