### PR TITLE
Update Manuscript generation to work with sibmei

### DIFF
--- a/tools/langs/manuscript.py
+++ b/tools/langs/manuscript.py
@@ -398,10 +398,11 @@ GetTail "(element) {
 
     meiDocumentToFile "(meidoc, filename) {
         meiout = _exportMeiDocument(meidoc);
-        Sibelius.CreateTextFile(filename);
-        Sibelius.AppendTextFile(filename, meiout, 1);
-
-        return true;
+        if (Sibelius.CreateTextFile(filename)) {
+            return Sibelius.AppendTextFile(filename, meiout, true);
+        } else {
+            return false;
+        }
 }"
 
     meiDocumentToString "(meidoc) {

--- a/tools/langs/manuscript.py
+++ b/tools/langs/manuscript.py
@@ -454,7 +454,7 @@ GetTail "(element) {
     _xmlImport "(filename) {
     /*
         Based on the Quick-n-Dirty XML parser at
-        http://www.javaworld.com/javatips/jw-javatip128.html
+        https://www.infoworld.com/article/2077493/java-tip-128--create-a-quick-and-dirty-xml-parser.html
     */
     xmlinput = Sibelius.ReadTextFile(filename, true);
     meidoc = CreateSparseArray();

--- a/tools/langs/manuscript.py
+++ b/tools/langs/manuscript.py
@@ -858,7 +858,7 @@ removeKeyFromDictionary "(dict, key) {
 }"
 """
 
-AUTHORS = "Andrew Hankinson, Alastair Porter, and Others"
+AUTHORS = "Andrew Hankinson, Alastair Porter, Thomas Weber and Others"
 
 FILE_TEMPLATE = """
 {{

--- a/tools/langs/manuscript.py
+++ b/tools/langs/manuscript.py
@@ -150,7 +150,7 @@ SetAttributes "(element, new_attrs) {
     // this will provide character encoding
     for each Pair a in new_attrs
     {
-        libmei.AddAttribute(element, a.Name, a.Value);
+        AddAttribute(element, a.Name, a.Value);
     }
 }"
 GetId "(element) {
@@ -299,12 +299,12 @@ GetTail "(element) {
     trace('convert: ');
     trace(meiel);
 
-    nm = libmei.GetName(meiel);
-    at = libmei.GetAttributes(meiel);
-    ch = libmei.GetChildren(meiel);
-    tx = libmei.GetText(meiel);
-    tl = libmei.GetTail(meiel);
-    id = libmei.GetId(meiel);
+    nm = GetName(meiel);
+    at = GetAttributes(meiel);
+    ch = GetChildren(meiel);
+    tx = GetText(meiel);
+    tl = GetTail(meiel);
+    id = GetId(meiel);
 
     tabs = '';
     if (indent > 0)
@@ -654,8 +654,8 @@ GetTail "(element) {
                     }
                     // doc.startElement(tagName, attrs);
                     ent = createEntry(tagName);
-                    libmei.setAttributes(ent, attrs);
-                    libmei.addChild(parentTag[-1], ent);
+                    setAttributes(ent, attrs);
+                    addChild(parentTag[-1], ent);
                     Self.MEIFlattened.Push(ent);
 
                     // doc.endElement(tagName);
@@ -680,8 +680,8 @@ GetTail "(element) {
                                 tagName = sb.Join('');
                             }
                             ent = createEntry(tagName);
-                            libmei.setAttributes(ent, attrs);
-                            libmei.addChild(parentTag[-1], ent);
+                            setAttributes(ent, attrs);
+                            addChild(parentTag[-1], ent);
                             parentTag.Push(ent);
                             Self.MEIFlattened.Push(ent);
 
@@ -803,9 +803,9 @@ GetTail "(element) {
                             mode = popMode(st);
                             // doc.startElement(tagname, attrs);
                             ent = createEntry(tagName);
-                            libmei.setAttributes(ent, attrs);
+                            setAttributes(ent, attrs);
                             if (parentTag.Length > 0) {
-                                libmei.addChild(parentTag[-1], ent);
+                                addChild(parentTag[-1], ent);
                             }
                             parentTag.Push(ent);
                             Self.MEIFlattened.Push(ent);

--- a/tools/langs/manuscript.py
+++ b/tools/langs/manuscript.py
@@ -451,7 +451,7 @@ GetTail "(element) {
     _xmlImport "(filename) {
     /*
         Based on the Quick-n-Dirty XML parser at
-        http://www.javaworld.com/javatips/jw-javatip128.html
+        https://www.infoworld.com/article/2077493/java-tip-128--create-a-quick-and-dirty-xml-parser.html
     */
     xmlinput = Sibelius.ReadTextFile(filename, true);
     meidoc = CreateSparseArray();

--- a/tools/langs/manuscript.py
+++ b/tools/langs/manuscript.py
@@ -360,11 +360,6 @@ GetTail "(element) {
         indent = indent - 1;
     }
 
-    if (Length(tl) > 0)
-    {
-        xmlout = xmlout & tl;
-    }
-
     // convertDictToXml takes care of adding the />
     // for tags that do not have children. We'll
     // take care of the terminal tag here for those
@@ -382,6 +377,11 @@ GetTail "(element) {
             xmlout = xmlout & tabs & '</' & nm & '>
 ';
         }
+    }
+
+    if (Length(tl) > 0)
+    {
+        xmlout = xmlout & tl;
     }
 
     return xmlout;


### PR DESCRIPTION
To avoid the need of conflict resolution with merging commits one by one, this pull request supersedes #111, #112, #116 and #117.

This includes changes that were made to the libmei shipping with sibmei.  For example, the [`RemoveChild()`](https://github.com/music-encoding/sibmei/blame/69a33cbcc05a99944578fd97b71fd6a8b0847523/lib/libmei.plg#L1297) method was added with [24f5b43 in 2015](https://github.com/music-encoding/sibmei/commit/24f5b43285602e6a403d4e172ce83176a5085516), but was never added to the libmei generator.

Goal is that we can generate libmei for sibmei without having to manually merge changes every time.