### PR TITLE
Fix boost-python version to work for different versions of python3

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -7,12 +7,7 @@ longdesc = """ Python Bindings for LibMEI. """
 
 if sys.platform == "darwin":
     link_args = ["-F", "/Library/Frameworks","-framework", "mei"]
-    if sys.version_info.major == 2:
-        libraries = ["boost_python27-mt"]
-    elif sys.version_info.major == 3:
-        libraries = ["boost_python3"+str(sys.version_info.minor)+"-mt"]
-    else:
-        libraries = ["boost_python-mt"]
+    libraries = ["boost_python{major}{minor}-mt".format(major=sys.version_info.major, minor=sys.version_info.minor)]
     library_dirs = []
     runtime_library_dirs = []
     include_dirs = []

--- a/python/setup.py
+++ b/python/setup.py
@@ -10,7 +10,7 @@ if sys.platform == "darwin":
     if sys.version_info.major == 2:
         libraries = ["boost_python27-mt"]
     elif sys.version_info.major == 3:
-        libraries = ["boost_python36-mt"]
+        libraries = ["boost_python3"+str(sys.version_info.minor)+"-mt"]
     else:
         libraries = ["boost_python-mt"]
     library_dirs = []


### PR DESCRIPTION
For python3, the `setup.py` script only looked for the `boost_python36-mt` version regardless of the actual version of python3 used. I changed this so that it looks for the version of boost-python corresponding to the correct python3 version. I have python3.9 and this fix works in looking for `boost_python39-mt`.